### PR TITLE
upgrade setuptools early

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Upgrade python setuptools
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade wheel setuptools setuptools_scm
+
       - name: Inspect version info
         run: | 
           python setup.py --version
@@ -45,11 +50,6 @@ jobs:
         run: |
           pip install .
           pip uninstall -y mud-examples
-
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-          pip install --upgrade wheel setuptools setuptools_scm
 
       - name: Test install with wheels
         run: |


### PR DESCRIPTION
the `build` workflow warned me of a bad set-up (["previously worked by accident"](https://github.com/mathematicalmichael/mud-examples/runs/6696700456?check_suite_focus=true#step:4:12)), and finally failed on a scheduled CI.
swapping the step where we upgrade setuptools and pip should do the trick.